### PR TITLE
v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "litra"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "exitcode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "litra"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
* Return the minimum and maximum temperature from the `devices` command, not a lost of allowed values. __This brings a breaking change when the command is called in `--json` mode, returning `minimum_temperature_in_kelvin` and `maximum_temperature_in_kelvin` instead of `allowed_temperatures_in_kelvin`.__
* When trying to use the `temperature` command to set a non- allowed temperature, return the minimum, maximum and rule (multiples of 100) rather than a list of allowed values.
* Improve built-in documentation for the `brightness` command to explain allowed values