### PR TITLE
Fix Windows support

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -38,10 +38,15 @@ jobs:
         with:
           args: --release --target=${{ matrix.job.target }} 
           command: build
-      - name: Rename binary to use structured filename
+      - name: Rename Windows binary to use structured filename
+        run: |
+          cp target/${{ matrix.job.target }}/release/litra.exe litra_${{ github.ref_name }}_${{ matrix.job.binary_name }}
+        if: runner.os == 'Windows'
+      - name: Rename Unix binary to use structured filename
         run: |
           rm target/${{ matrix.job.target }}/release/litra.d
           cp target/${{ matrix.job.target }}/release/litra* litra_${{ github.ref_name }}_${{ matrix.job.binary_name }}
+        if: runner.os != 'Windows'
       - name: Upload binary as artifact
         uses: actions/upload-artifact@v4
         with:

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,7 @@ struct Device {
 
 const VENDOR_ID: u16 = 0x046d;
 const PRODUCT_IDS: [u16; 4] = [0xc900, 0xc901, 0xb901, 0xc903];
+const USAGE_PAGE: u16 = 0xff43;
 
 fn get_device_type(product_id: u16) -> DeviceType {
     match product_id {
@@ -146,7 +147,10 @@ fn get_connected_devices(api: HidApi, serial_number: Option<String>) -> Vec<Devi
     let mut litra_devices = Vec::new();
 
     for device in hid_devices {
-        if device.vendor_id() == VENDOR_ID && PRODUCT_IDS.contains(&device.product_id()) {
+        if device.vendor_id() == VENDOR_ID
+            && PRODUCT_IDS.contains(&device.product_id())
+            && device.usage_page() == USAGE_PAGE
+        {
             if let Some(serial_number) = &serial_number {
                 if device.serial_number().unwrap_or("") != *serial_number {
                     continue;
@@ -156,9 +160,6 @@ fn get_connected_devices(api: HidApi, serial_number: Option<String>) -> Vec<Devi
             litra_devices.push(device);
         }
     }
-
-    // On my macOS Sonoma device, every Litra device is returned twice for some reason
-    litra_devices.dedup_by(|a, b| a.path() == b.path());
 
     return litra_devices
         .iter()


### PR DESCRIPTION
This fixes Windows support in the tool by:

* (a) **picking the correct HID device based on its usage page**. Litra devices present as two HID devices. By chance, on macOS and Linux, we seem to pick the right one, but on Windows, the wrong one gets picked and nothing works.
* (b) **fixing the build and release process**. We were taking the wrong file and renaming it to `.exe`, which meant that it wasn't actually executable. Oops!