### PR TITLE
Add more package metadata to `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,13 @@
 name = "litra"
 version = "0.2.1"
 edition = "2021"
+author = "Tim Rogers <timrogers@github.com>"
+description = "Control your Logitech Litra light from the command line."
+repository = "https://github.com/timrogers/litra-rs.git"
+license = "MIT"
+readme-file = "README.md"
+categories = ["hardware-support", "command-line-utilities"]
+keywords = ["logitech", "litra", "glow", "beam", "light"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This should be sufficient for pushing to crates.io (at least `cargo publish --dry-run` does not complain about missing metadata).

Have a look at https://doc.rust-lang.org/book/ch14-02-publishing-to-crates-io.html#publishing-to-cratesio for documentation how to do that.