### PR TITLE
v1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "litra"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "clap",
  "hidapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "litra"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 authors = ["Tim Rogers <timrogers@github.com>"]
 description = "Control your Logitech Litra light from the command line"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ With this tool, you can:
 - Check if the light is on or off
 - Set and get the brightness of your light
 - Set and get the temperature of your light
+- Automatically turn the light on and off when your webcam turns on or off (Linux only)
 
 ## Supported devices
 
@@ -59,8 +60,9 @@ The following commands are available for controlling your devices:
 - `litra on`: Turn your Logitech Litra device on
 - `litra off`: Turn your Logitech Litra device off
 - `litra toggle`: Toggles your Logitech Litra device on or off
-- `litra brightness`:  Sets the brightness of your Logitech Litra device, using either `--value` (measured in lumens) or `--percentage` (as a percentage of the device's maximum brightness). The brightness can be set to any value between the minimum and maximum for the device returned by the `devices` command.
-- `litra temperature`:  Sets the temperature of your Logitech Litra device, using a `--value` measured in kelvin (K). The temperature be set to any multiple of 100 between the minimum and maximum for the device returned by the `devices` command.
+- `litra brightness`: Sets the brightness of your Logitech Litra device, using either `--value` (measured in lumens) or `--percentage` (as a percentage of the device's maximum brightness). The brightness can be set to any value between the minimum and maximum for the device returned by the `devices` command.
+- `litra temperature`: Sets the temperature of your Logitech Litra device, using a `--value` measured in kelvin (K). The temperature be set to any multiple of 100 between the minimum and maximum for the device returned by the `devices` command.
+- `litra auto-toggle` **(Linux only)**: Automatically turns your Logitech Litra device on when your webcam starts capturing video, and off when it stops capturing video. This command should be left running in the background.
 
 All of the these commands support a `--serial-number`/`-s` argument to specify the serial number of the device you want to target. If you only have one Litra device, you can omit this argument. If you have multiple devices, we recommend specifying it. If it isn't specified, the "first" device will be picked, but this isn't guaranteed to be stable between command runs.
 


### PR DESCRIPTION
- Add new `auto-toggle` command *(Linux only)* which automatically turns your Logitech Litra device on when your webcam starts capturing video, and off when it stops capturing video (@Holzhaus)