### PR TITLE
bugfix: Allow temperature values greater than minimum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "litra"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "clap",
  "hidapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "litra"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 authors = ["Tim Rogers <timrogers@github.com>"]
 description = "Control your Logitech Litra light from the command line"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,7 +281,7 @@ impl DeviceHandle {
 
     /// Sets the device's color temperature in Kelvin.
     pub fn set_temperature_in_kelvin(&self, temperature_in_kelvin: u16) -> DeviceResult<()> {
-        if self.minimum_temperature_in_kelvin() < temperature_in_kelvin
+        if temperature_in_kelvin < self.minimum_temperature_in_kelvin()
             || temperature_in_kelvin > self.maximum_temperature_in_kelvin()
             || (temperature_in_kelvin % 100) != 0
         {


### PR DESCRIPTION
Found a bug that wouldn't allow temperatures greater than the minimum to be set, and instead allowed temperatures _lower_ than the minimum.

Bumped the patch, to version 1.1.1