### PR TITLE
Expose serial number & HidDevice

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ impl Litra {
     }
 
     /// Returns an [`Iterator`] of connected devices supported by this library.
-    pub fn get_connected_devices(&self) -> impl Iterator<Item=Device<'_>> {
+    pub fn get_connected_devices(&self) -> impl Iterator<Item = Device<'_>> {
         self.0
             .device_list()
             .filter_map(|device_info| Device::try_from(device_info).ok())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,9 +31,10 @@
 #![cfg_attr(not(test), deny(clippy::panic_in_result_fn))]
 #![cfg_attr(not(debug_assertions), deny(clippy::used_underscore_binding))]
 
-use hidapi::{DeviceInfo, HidApi, HidDevice, HidError};
 use std::error::Error;
 use std::fmt;
+
+use hidapi::{DeviceInfo, HidApi, HidDevice, HidError};
 
 /// Litra context.
 ///
@@ -53,7 +54,7 @@ impl Litra {
     }
 
     /// Returns an [`Iterator`] of connected devices supported by this library.
-    pub fn get_connected_devices(&self) -> impl Iterator<Item = Device<'_>> {
+    pub fn get_connected_devices(&self) -> impl Iterator<Item=Device<'_>> {
         self.0
             .device_list()
             .filter_map(|device_info| Device::try_from(device_info).ok())
@@ -208,9 +209,9 @@ impl DeviceHandle {
     }
 
     /// Returns the serial number of the device.
-    pub fn serial_number(&self) -> DeviceResult<Option<&str>> {
+    pub fn serial_number(&self) -> DeviceResult<Option<String>> {
         match self.hid_device.get_device_info() {
-            Ok(device_info) => Ok(device_info.serial_number()),
+            Ok(device_info) => Ok(device_info.serial_number().map(String::from)),
             Err(error) => Err(DeviceError::HidError(error)),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,8 +102,6 @@ pub enum DeviceError {
     InvalidBrightness(u16),
     /// Tried to set an invalid temperature value.
     InvalidTemperature(u16),
-    /// Device didn't return a serial number.
-    NoSerial,
     /// A [`hidapi`] operation failed.
     HidError(HidError),
 }
@@ -118,7 +116,6 @@ impl fmt::Display for DeviceError {
             DeviceError::InvalidTemperature(value) => {
                 write!(f, "Temperature {} K is not supported", value)
             }
-            DeviceError::NoSerial => write!(f, "Device doesn't have a serial number"),
             DeviceError::HidError(error) => write!(f, "HID error occurred: {}", error),
         }
     }
@@ -211,12 +208,9 @@ impl DeviceHandle {
     }
 
     /// Returns the serial number of the device.
-    pub fn serial_number(&self) -> DeviceResult<&str> {
+    pub fn serial_number(&self) -> DeviceResult<Option<&str>> {
         match self.hid_device.get_device_info() {
-            Ok(device_info) => match device_info.serial_number() {
-                Some(serial_number) => Ok(serial_number),
-                None => Err(DeviceError::NoSerial),
-            },
+            Ok(device_info) => Ok(device_info.serial_number()),
             Err(error) => Err(DeviceError::HidError(error)),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,10 +31,9 @@
 #![cfg_attr(not(test), deny(clippy::panic_in_result_fn))]
 #![cfg_attr(not(debug_assertions), deny(clippy::used_underscore_binding))]
 
+use hidapi::{DeviceInfo, HidApi, HidDevice, HidError};
 use std::error::Error;
 use std::fmt;
-
-use hidapi::{DeviceInfo, HidApi, HidDevice, HidError};
 
 /// Litra context.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ impl Litra {
     }
 
     /// Returns an [`Iterator`] of connected devices supported by this library.
-    pub fn get_connected_devices(&self) -> impl Iterator<Item=Device<'_>> {
+    pub fn get_connected_devices(&self) -> impl Iterator<Item = Device<'_>> {
         self.0
             .device_list()
             .filter_map(|device_info| Device::try_from(device_info).ok())


### PR DESCRIPTION
Hey,
While working on a personal project and stumbled upon your library!

However, I noticed a couple of features that I need are missing: specifically, access to the underlying `HidDevice` and an easy way to retrieve the device's serial number.

So I thought I'd contribute!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new error variant, `NoSerial`, for improved error handling related to missing serial numbers.
	- Added new public methods to access the underlying device and retrieve the device's serial number.

- **Improvements**
	- Enhanced error reporting for device management, providing clearer messages when serial numbers are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->