### PR TITLE
Build for Apple Silicon (`darwin-arm64`) devices in CI, and sign and notarize all macOS binaries

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -67,11 +67,41 @@ jobs:
           rm target/${{ matrix.job.target }}/release/litra.d
           cp target/${{ matrix.job.target }}/release/litra* litra_${{ steps.sanitise_ref.outputs.value }}_${{ matrix.job.binary_name }}
         if: runner.os != 'Windows'
+      - name: Write Apple signing key to a file (macOS only)
+        env:
+          APPLE_SIGNING_KEY_P12: ${{ secrets.APPLE_SIGNING_KEY_P12 }}
+        run: echo "$APPLE_SIGNING_KEY_P12" | base64 -d -o key.p12
+        if: matrix.job.os == 'macos-latest'
+      - name: Write App Store Connect API key to a file (macOS only)
+        env:
+          APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+        run: echo "$APP_STORE_CONNECT_API_KEY" > app_store_connect_api_key.json
+        if: matrix.job.os == 'macos-latest'
+      - name: Sign macOS binary (macOS only)
+        uses: indygreg/apple-code-sign-action@v1
+        with:
+          input_path: litra_${{ steps.sanitise_ref.outputs.value }}_${{ matrix.job.binary_name }}
+          p12_file: key.p12
+          p12_password: ${{ secrets.APPLE_SIGNING_KEY_PASSWORD }}
+          sign: true
+          sign_args: "--code-signature-flags=runtime"
+        if: matrix.job.os == 'macos-latest'
       - name: Upload binary as artifact
         uses: actions/upload-artifact@v4
         with:
           path: litra_${{ steps.sanitise_ref.outputs.value }}_${{ matrix.job.binary_name }}
           name: litra_${{ steps.sanitise_ref.outputs.value }}_${{ matrix.job.binary_name }}
+      - name: Archive macOS binary for notarisation (macOS only)
+        run: zip litra_${{ steps.sanitise_ref.outputs.value }}_${{ matrix.job.binary_name }}.zip litra_${{ steps.sanitise_ref.outputs.value }}_${{ matrix.job.binary_name }}
+        if: matrix.job.os == 'macos-latest'
+      - name: Notarise signed macOS binary (macOS only)
+        uses: indygreg/apple-code-sign-action@v1
+        with:
+          input_path: litra_${{ steps.sanitise_ref.outputs.value }}_${{ matrix.job.binary_name }}.zip
+          sign: false
+          notarize: true
+          app_store_connect_api_key_json_file: app_store_connect_api_key.json
+        if: matrix.job.os == 'macos-latest'
   cargo_publish_dry_run:
     name: Publish with Cargo in dry-run mode
     runs-on: ubuntu-latest

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -9,9 +9,26 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { target: x86_64-unknown-linux-gnu, binary_name: linux-amd64, os: ubuntu-latest }
-          - { target: x86_64-apple-darwin, binary_name: darwin-amd64, os: macos-latest }
-          - { target: x86_64-pc-windows-msvc, binary_name: windows-amd64.exe, os: windows-latest }
+          - {
+              target: x86_64-unknown-linux-gnu,
+              binary_name: linux-amd64,
+              os: ubuntu-latest,
+            }
+          - {
+              target: x86_64-apple-darwin,
+              binary_name: darwin-amd64,
+              os: macos-latest,
+            }
+          - {
+              target: aarch64-apple-darwin,
+              binary_name: darwin-arm64,
+              os: macos-latest,
+            }
+          - {
+              target: x86_64-pc-windows-msvc,
+              binary_name: windows-amd64.exe,
+              os: windows-latest,
+            }
     runs-on: ${{ matrix.job.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add Apple Silicon build and signing support to CI workflow for macOS in `build_and_release.yml`.
> 
>   - **CI Workflow**:
>     - Add `aarch64-apple-darwin` target to build matrix in `build_and_release.yml` for Apple Silicon support.
>     - Introduce `darwin-arm64` as binary name for ARM64 macOS builds.
>     - Add steps to sign and notarize macOS binaries using `indygreg/apple-code-sign-action@v1` when `os` is `macos-latest`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=timrogers%2Flitra-rs&utm_source=github&utm_medium=referral)<sup> for 9ea45f59c0d82e50c4c24f42f81b595ed3f3d1ac. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for building binaries for the new `aarch64-apple-darwin` architecture on macOS.

- **Improvements**
	- Enhanced job matrix configuration for better readability and structure.
	- Introduced signing and notarization steps for macOS binaries to ensure security and compliance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->