### PR TITLE
Fix "Publish with Cargo in dry-run mode" CI job by setting a dummy version which doesn't already exist

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -77,8 +77,12 @@ jobs:
           components: rustc, cargo
           toolchain: nightly
           override: true
+      - name: Install cargo-edit
+        run: cargo install cargo-edit
+      - name: Set the version to a dummy version to allow publishing
+        run: cargo set-version 9.9.9
       - name: Publish to Crates.io
-        run: cargo publish --dry-run
+        run: cargo publish --dry-run --allow-dirty
   create_github_release:
     name: Create release with binary assets
     runs-on: ubuntu-latest


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes CI workflow by setting a dummy version for dry-run publishing in `build_and_release.yml`.
> 
>   - **CI Workflow**:
>     - In `build_and_release.yml`, added step to install `cargo-edit`.
>     - Set package version to `9.9.9` before `cargo publish --dry-run` to avoid version conflicts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=timrogers%2Flitra-rs&utm_source=github&utm_medium=referral)<sup> for 9ab7e43d51b27e11d15a29a95463bd0052c3d216. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->