### PR TITLE
Mark `tokio` as an optional dependency, used only for the binary target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,11 @@ hidapi = "2.6.3"
 clap = { version = "4.5.13", features = ["derive"], optional = true }
 serde = { version = "1.0.210", features = ["derive"], optional = true }
 serde_json = { version = "1.0.122", optional = true }
-tokio = { version = "1.40.0", features = ["full"] }
+tokio = { version = "1.40.0", features = ["full"], optional = true }
 
 [features]
 default = ["cli"]
-cli = ["dep:clap", "dep:serde", "dep:serde_json", "dep:inotify"]
+cli = ["dep:clap", "dep:serde", "dep:serde_json", "dep:inotify", "dep:tokio"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 inotify = { version = "0.11.0", optional = true }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Mark `tokio` as an optional dependency and include it in the `cli` feature in `Cargo.toml`.
> 
>   - **Dependencies**:
>     - Mark `tokio` as optional in `Cargo.toml`.
>     - Add `tokio` to `cli` feature dependencies in `Cargo.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=timrogers%2Flitra-rs&utm_source=github&utm_medium=referral)<sup> for 9408d3a5794a364ca8b1965387acddd482a91ca3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the command-line interface functionality to include optional support for `tokio`.
  
- **Chores**
	- Updated the package version to `1.3.0`.
	- Retained lint settings for improved code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->