### PR TITLE
Include the darwin-arm64 binary as an asset when publishing a release

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -147,6 +147,9 @@ jobs:
           name: litra_${{ steps.sanitise_ref.outputs.value }}_darwin-amd64
       - uses: actions/download-artifact@v4
         with:
+          name: litra_${{ steps.sanitise_ref.outputs.value }}_darwin-arm64
+      - uses: actions/download-artifact@v4
+        with:
           name: litra_${{ steps.sanitise_ref.outputs.value }}_windows-amd64.exe
       - name: Create release
         uses: softprops/action-gh-release@v2
@@ -154,6 +157,7 @@ jobs:
           files: |
             litra_${{ steps.sanitise_ref.outputs.value }}_windows-amd64.exe
             litra_${{ steps.sanitise_ref.outputs.value }}_darwin-amd64
+            litra_${{ steps.sanitise_ref.outputs.value }}_darwin-arm64
             litra_${{ steps.sanitise_ref.outputs.value }}_linux-amd64
   publish_on_homebrew:
     name: Publish release on Homebrew


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `darwin-arm64` binary to release assets in GitHub Actions workflow.
> 
>   - **GitHub Actions Workflow**:
>     - In `build_and_release.yml`, add `darwin-arm64` binary to the `create_github_release` job.
>     - Modify `download-artifact` steps to include `litra_${{ steps.sanitise_ref.outputs.value }}_darwin-arm64`.
>     - Update `action-gh-release` step to include `darwin-arm64` in release assets.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=timrogers%2Flitra-rs&utm_source=github&utm_medium=referral)<sup> for 2c883c5dee37b3bb4f13c2300576cd52051c84d2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->