### PR TITLE
Create, sign and notarize and release a universal macOS binary

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -124,12 +124,10 @@ jobs:
         env:
           APPLE_SIGNING_KEY_P12: ${{ secrets.APPLE_SIGNING_KEY_P12 }}
         run: echo "$APPLE_SIGNING_KEY_P12" | base64 -d -o key.p12
-        if: matrix.job.os == 'macos-latest'
       - name: Write App Store Connect API key to a file (macOS only)
         env:
           APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
         run: echo "$APP_STORE_CONNECT_API_KEY" > app_store_connect_api_key.json
-        if: matrix.job.os == 'macos-latest'
       - name: Sign macOS binary (macOS only)
         uses: indygreg/apple-code-sign-action@v1
         with:

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -119,9 +119,7 @@ jobs:
         with:
           name: litra_${{ steps.sanitise_ref.outputs.value }}_darwin-arm64
       - name: Create universal macOS binary
-        run: lipo -create -output litra_${{ steps.sanitise_ref.outputs.value }}_darwin-universal \
-          litra_${{ steps.sanitise_ref.outputs.value }}_darwin-amd64 \
-          litra_${{ steps.sanitise_ref.outputs.value }}_darwin-arm64
+        run: lipo -create -output litra_${{ steps.sanitise_ref.outputs.value }}_darwin-universal litra_${{ steps.sanitise_ref.outputs.value }}_darwin-amd64 litra_${{ steps.sanitise_ref.outputs.value }}_darwin-arm64
       - name: Write Apple signing key to a file (macOS only)
         env:
           APPLE_SIGNING_KEY_P12: ${{ secrets.APPLE_SIGNING_KEY_P12 }}

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -227,7 +227,7 @@ jobs:
       - uses: mislav/bump-homebrew-formula-action@v3
         with:
           formula-name: litra
-          download-url: https://github.com/timrogers/litra-rs/releases/download/${{ steps.get_version.outputs.VERSION }}/litra_${{ steps.get_version.outputs.VERSION }}_darwin-amd64
+          download-url: https://github.com/timrogers/litra-rs/releases/download/${{ steps.get_version.outputs.VERSION }}/litra_${{ steps.get_version.outputs.VERSION }}_darwin-universal
           homebrew-tap: timrogers/homebrew-tap
           push-to: timrogers/homebrew-tap
           create-pullrequest: true

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -107,6 +107,9 @@ jobs:
     runs-on: macos-latest
     needs: build
     steps:
+      - name: Sanitise Git ref for use in filenames
+        id: sanitise_ref
+        run: echo "::set-output name=value::$(echo "${{ github.ref_name }}" | tr '/' '_')"
       - name: Download macOS amd64 binary
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -150,7 +150,7 @@ jobs:
           sign: false
           notarize: true
           app_store_connect_api_key_json_file: app_store_connect_api_key.json
-          
+
   cargo_publish_dry_run:
     name: Publish with Cargo in dry-run mode
     runs-on: ubuntu-latest
@@ -182,7 +182,7 @@ jobs:
   create_github_release:
     name: Create release with binary assets
     runs-on: ubuntu-latest
-    needs: 
+    needs:
       - build
       - create_and_sign_macos_universal_binary
     if: startsWith(github.event.ref, 'refs/tags/v')

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -102,6 +102,56 @@ jobs:
           notarize: true
           app_store_connect_api_key_json_file: app_store_connect_api_key.json
         if: matrix.job.os == 'macos-latest'
+  create_and_sign_macos_universal_binary:
+    name: Create and sign macOS universal binary (macOS only)
+    runs-on: macos-latest
+    needs: build
+    steps:
+      - name: Download macOS amd64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: litra_${{ steps.sanitise_ref.outputs.value }}_darwin-amd64
+      - name: Download macOS arm64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: litra_${{ steps.sanitise_ref.outputs.value }}_darwin-arm64
+      - name: Create universal macOS binary
+        run: lipo -create -output litra_${{ steps.sanitise_ref.outputs.value }}_darwin-universal \
+          litra_${{ steps.sanitise_ref.outputs.value }}_darwin-amd64 \
+          litra_${{ steps.sanitise_ref.outputs.value }}_darwin-arm64
+      - name: Write Apple signing key to a file (macOS only)
+        env:
+          APPLE_SIGNING_KEY_P12: ${{ secrets.APPLE_SIGNING_KEY_P12 }}
+        run: echo "$APPLE_SIGNING_KEY_P12" | base64 -d -o key.p12
+        if: matrix.job.os == 'macos-latest'
+      - name: Write App Store Connect API key to a file (macOS only)
+        env:
+          APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+        run: echo "$APP_STORE_CONNECT_API_KEY" > app_store_connect_api_key.json
+        if: matrix.job.os == 'macos-latest'
+      - name: Sign macOS binary (macOS only)
+        uses: indygreg/apple-code-sign-action@v1
+        with:
+          input_path: litra_${{ steps.sanitise_ref.outputs.value }}_darwin-universal
+          p12_file: key.p12
+          p12_password: ${{ secrets.APPLE_SIGNING_KEY_PASSWORD }}
+          sign: true
+          sign_args: "--code-signature-flags=runtime"
+      - name: Upload binary as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          path: litra_${{ steps.sanitise_ref.outputs.value }}_darwin-universal
+          name: litra_${{ steps.sanitise_ref.outputs.value }}_darwin-universal
+      - name: Archive macOS binary for notarisation (macOS only)
+        run: zip litra_${{ steps.sanitise_ref.outputs.value }}_darwin-universal.zip litra_${{ steps.sanitise_ref.outputs.value }}_darwin-universal
+      - name: Notarise signed macOS binary (macOS only)
+        uses: indygreg/apple-code-sign-action@v1
+        with:
+          input_path: litra_${{ steps.sanitise_ref.outputs.value }}_darwin-universal.zip
+          sign: false
+          notarize: true
+          app_store_connect_api_key_json_file: app_store_connect_api_key.json
+          
   cargo_publish_dry_run:
     name: Publish with Cargo in dry-run mode
     runs-on: ubuntu-latest
@@ -133,7 +183,9 @@ jobs:
   create_github_release:
     name: Create release with binary assets
     runs-on: ubuntu-latest
-    needs: build
+    needs: 
+      - build
+      - create_and_sign_macos_universal_binary
     if: startsWith(github.event.ref, 'refs/tags/v')
     steps:
       - name: Sanitise Git ref for use in filenames
@@ -150,6 +202,9 @@ jobs:
           name: litra_${{ steps.sanitise_ref.outputs.value }}_darwin-arm64
       - uses: actions/download-artifact@v4
         with:
+          name: litra_${{ steps.sanitise_ref.outputs.value }}_darwin-universal
+      - uses: actions/download-artifact@v4
+        with:
           name: litra_${{ steps.sanitise_ref.outputs.value }}_windows-amd64.exe
       - name: Create release
         uses: softprops/action-gh-release@v2
@@ -159,6 +214,7 @@ jobs:
             litra_${{ steps.sanitise_ref.outputs.value }}_darwin-amd64
             litra_${{ steps.sanitise_ref.outputs.value }}_darwin-arm64
             litra_${{ steps.sanitise_ref.outputs.value }}_linux-amd64
+            litra_${{ steps.sanitise_ref.outputs.value }}_darwin-universal
   publish_on_homebrew:
     name: Publish release on Homebrew
     runs-on: ubuntu-latest


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add GitHub Actions job to create, sign, and notarize a universal macOS binary and update release process.
> 
>   - **Workflow Changes**:
>     - Add `create_and_sign_macos_universal_binary` job to `.github/workflows/build_and_release.yml` for creating, signing, and notarizing a universal macOS binary.
>     - Update `create_github_release` job to depend on `create_and_sign_macos_universal_binary`.
>     - Include `litra_${{ steps.sanitise_ref.outputs.value }}_darwin-universal` in release assets.
>   - **Binary Creation**:
>     - Use `lipo` to create a universal binary from `darwin-amd64` and `darwin-arm64` binaries.
>     - Sign and notarize the universal binary using Apple tools.
>   - **Homebrew**:
>     - Update Homebrew formula download URL to use the universal binary.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=timrogers%2Flitra-rs&utm_source=github&utm_medium=referral)<sup> for 2f2ab145a5b3a19407a8b988ac3467d9d898acce. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->