### PR TITLE
Avoid taking an exclusive lock on Litra devices on macOS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,10 @@ impl fmt::Debug for Litra {
 impl Litra {
     /// Initialize a new Litra context.
     pub fn new() -> DeviceResult<Self> {
-        Ok(HidApi::new().map(Litra)?)
+        let hidapi = HidApi::new()?;
+        #[cfg(target_os = "macos")]
+        hidapi.set_open_exclusive(false);
+        Ok(Litra(hidapi))
     }
 
     /// Returns an [`Iterator`] of connected devices supported by this library.
@@ -177,7 +180,7 @@ impl Device<'_> {
     }
 
     /// Opens the device and returns a [`DeviceHandle`] that can be used for getting and setting the
-    /// device status.
+    /// device status. On macOS, this will open the device in non-exclusive mode.
     pub fn open(&self, context: &Litra) -> DeviceResult<DeviceHandle> {
         let hid_device = self.device_info.open_device(context.hidapi())?;
         Ok(DeviceHandle {


### PR DESCRIPTION
Currently, when a Litra handle device is opened with `open()`, on macOS we take an exclusive lock on the device, which stops it being managed by other applications.

This isn't a problem if the device handle is quickly closed again (e.g. if the application exits), but it can be annoying if you have a long-running application that holds onto the device handle for a long time (e.g. `litra auto-toggle`).

As an example, if you run `litra auto-toggle` and then try to turn the device on or off with `litra on` or `litra off` in another shell, it would fail with an error:

> HID error occurred: hidapi error: hid_open_path: failed to open IOHIDDevice from mach entry: (0xE00002C5) (iokit/common) exclusive access and device already open

This switches to taking a non-exclusive lock on macOS, affecting use of this code as a Rust library and our long-running `auto-toggle` command.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> On macOS, `Litra::new()` now avoids exclusive locks, allowing concurrent device access.
> 
>   - **Behavior**:
>     - On macOS, `Litra::new()` now sets `set_open_exclusive(false)` to avoid exclusive locks on devices.
>     - Updates `open()` docstring in `Device` to indicate non-exclusive mode on macOS.
>   - **Code**:
>     - Adds `hidapi.set_open_exclusive(false);` in `Litra::new()` for macOS.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=timrogers%2Flitra-rs&utm_source=github&utm_medium=referral)<sup> for a945f6cf4348b7cb83ad1896aaf7ccd7ca8afb92. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced support for macOS, allowing multiple applications to access devices simultaneously.
  
- **Documentation**
  - Improved documentation for the `open` method, clarifying non-exclusive mode behavior on macOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->