### PR TITLE
v1.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,7 +239,7 @@ checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "litra"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "clap",
  "hidapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "litra"
-version = "1.4.0"
+version = "1.5.0"
 edition = "2021"
 authors = ["Tim Rogers <timrogers@github.com>"]
 description = "Control your Logitech Litra light from the command line"


### PR DESCRIPTION
* **Open handles to Litra devices in non-exclusive mode on macOS**, allowing other Litra commands to be executed while `litra auto-toggle` is running
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `litra` to version 1.5.0, enabling non-exclusive mode for Litra devices on macOS to allow concurrent command execution.
> 
>   - **Behavior**:
>     - Open handles to Litra devices in non-exclusive mode on macOS, allowing concurrent execution of Litra commands with `litra auto-toggle`.
>   - **Versioning**:
>     - Update `litra` version to `1.5.0` in `Cargo.toml` and `Cargo.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=timrogers%2Flitra-rs&utm_source=github&utm_medium=referral)<sup> for a1bcb5e448363812c36d2b6d025c972266c629d0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the version number of the `litra` package to 1.5.0. 

This change ensures users are aware of the latest version available for use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->