### PR TITLE
Output a clear "No Logitech Litra devices found" message from `litra devices` when no devices are connected

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -292,34 +292,39 @@ fn handle_devices_command(json: bool) -> CliResult {
         );
         Ok(())
     } else {
-        for device_info in &litra_devices {
-            println!(
-                "- {} ({}): {} {}",
-                device_info.device_type,
-                device_info.serial_number,
-                get_is_on_text(device_info.is_on),
-                get_is_on_emoji(device_info.is_on)
-            );
+        if litra_devices.is_empty() {
+            println!("No Logitech Litra devices found");
+        } else {
+            for device_info in &litra_devices {
+                println!(
+                    "- {} ({}): {} {}",
+                    device_info.device_type,
+                    device_info.serial_number,
+                    get_is_on_text(device_info.is_on),
+                    get_is_on_emoji(device_info.is_on)
+                );
 
-            println!("  - Brightness: {} lm", device_info.brightness_in_lumen);
-            println!(
-                "    - Minimum: {} lm",
-                device_info.minimum_brightness_in_lumen
-            );
-            println!(
-                "    - Maximum: {} lm",
-                device_info.maximum_brightness_in_lumen
-            );
-            println!("  - Temperature: {} K", device_info.temperature_in_kelvin);
-            println!(
-                "    - Minimum: {} K",
-                device_info.minimum_temperature_in_kelvin
-            );
-            println!(
-                "    - Maximum: {} K",
-                device_info.maximum_temperature_in_kelvin
-            );
+                println!("  - Brightness: {} lm", device_info.brightness_in_lumen);
+                println!(
+                    "    - Minimum: {} lm",
+                    device_info.minimum_brightness_in_lumen
+                );
+                println!(
+                    "    - Maximum: {} lm",
+                    device_info.maximum_brightness_in_lumen
+                );
+                println!("  - Temperature: {} K", device_info.temperature_in_kelvin);
+                println!(
+                    "    - Minimum: {} K",
+                    device_info.minimum_temperature_in_kelvin
+                );
+                println!(
+                    "    - Maximum: {} K",
+                    device_info.maximum_temperature_in_kelvin
+                );
+            }
         }
+
         Ok(())
     }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add message in `handle_devices_command()` to indicate no Logitech Litra devices are found.
> 
>   - **Behavior**:
>     - In `handle_devices_command()` in `main.rs`, added a check for empty `litra_devices` and print "No Logitech Litra devices found" if true.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=timrogers%2Flitra-rs&utm_source=github&utm_medium=referral)<sup> for 42d3c2e3cb7efd6c7918bd4e73b9b9c54c6ce5d7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved feedback for users by displaying a message when no Logitech Litra devices are connected.
	- Enhanced output with detailed information about connected devices, including type, serial number, status, brightness, and temperature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->