### PR TITLE
Drop `auto-toggle` command, now moved to separate `litra-autotoggle` package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
-
-[[package]]
 name = "anstream"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,39 +50,6 @@ dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "autocfg"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
-name = "backtrace"
-version = "0.3.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "bitflags"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
-
-[[package]]
-name = "bytes"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cc"
@@ -161,28 +113,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
-name = "futures-core"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
-
-[[package]]
-name = "gimli"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hidapi"
@@ -195,28 +129,6 @@ dependencies = [
  "libc",
  "pkg-config",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "inotify"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
-dependencies = [
- "bitflags",
- "futures-core",
- "inotify-sys",
- "libc",
- "tokio",
-]
-
-[[package]]
-name = "inotify-sys"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -243,20 +155,8 @@ version = "1.6.0"
 dependencies = [
  "clap",
  "hidapi",
- "inotify",
  "serde",
  "serde_json",
- "tokio",
-]
-
-[[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
 ]
 
 [[package]]
@@ -264,65 +164,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
-dependencies = [
- "adler2",
-]
-
-[[package]]
-name = "mio"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
-dependencies = [
- "hermit-abi",
- "libc",
- "wasi",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "object"
-version = "0.36.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pkg-config"
@@ -349,31 +190,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -414,31 +234,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "smallvec"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
-
-[[package]]
-name = "socket2"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,35 +251,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
-dependencies = [
- "backtrace",
- "bytes",
- "libc",
- "mio",
- "parking_lot",
- "pin-project-lite",
- "signal-hook-registry",
- "socket2",
- "tokio-macros",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,12 +261,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,10 @@ hidapi = "2.6.3"
 clap = { version = "4.5.13", features = ["derive"], optional = true }
 serde = { version = "1.0.210", features = ["derive"], optional = true }
 serde_json = { version = "1.0.122", optional = true }
-tokio = { version = "1.40.0", features = ["full"], optional = true }
 
 [features]
 default = ["cli"]
-cli = ["dep:clap", "dep:serde", "dep:serde_json", "dep:inotify", "dep:tokio"]
-
-[target.'cfg(target_os = "linux")'.dependencies]
-inotify = { version = "0.11.0", optional = true }
+cli = ["dep:clap", "dep:serde", "dep:serde_json"]
 
 # TODO: Remove this once we're on a newer tokio version that doesn't trip this up
 # https://github.com/tokio-rs/tokio/pull/6874

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ With this tool, you can:
 - Check if the light is on or off
 - Set, get, increase and decrease the brightness of your light
 - Set, get, increase and decrease the temperature of your light
-- Automatically turn the light on and off when your webcam turns on or off (macOS and Linux only)
+
+> [!TIP]
+> 🖲️ Want to automatically turn your Litra on and off when your webcam turns on and off? Check out [`litra-autotoggle`](https://github.com/timrogers/litra-autotoggle)!
 
 ## Supported devices
 
@@ -66,7 +68,6 @@ The following commands are available for controlling your devices:
 - `litra temperature`: Sets the temperature of your Logitech Litra device, using a `--value` measured in kelvin (K). The temperature be set to any multiple of 100 between the minimum and maximum for the device returned by the `devices` command.
 - `litra temperature-up`: Increases the temperature of your Logitech Litra device, using a `--value` measured in kelvin (K). The value must be a multiple of 100.
 - `litra temperature-down`: Decreases the temperature of your Logitech Litra device, using a `--value` measured in kelvin (K). The value must be a multiple of 100.
-- `litra auto-toggle` **(macOS and Linux only)**: Automatically turns your Logitech Litra device on when your webcam starts capturing video, and off when it stops capturing video. This command should be left running in the background.
 
 All of the these commands support a `--serial-number`/`-s` argument to specify the serial number of the device you want to target. If you only have one Litra device, you can omit this argument. If you have multiple devices, we recommend specifying it. If it isn't specified, the "first" device will be picked, but this isn't guaranteed to be stable between command runs.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,9 @@
 use clap::{ArgGroup, Parser, Subcommand};
-#[cfg(target_os = "linux")]
-use inotify::{EventMask, Inotify, WatchMask};
 use litra::{Device, DeviceError, DeviceHandle, Litra};
 use serde::Serialize;
 use std::fmt;
 use std::num::TryFromIntError;
 use std::process::ExitCode;
-#[cfg(target_os = "macos")]
-use std::process::Stdio;
-#[cfg(target_os = "macos")]
-use tokio::io::{AsyncBufReadExt, BufReader};
-#[cfg(target_os = "macos")]
-use tokio::process::Command;
 
 /// Control your USB-connected Logitech Litra lights from the command line
 #[derive(Debug, Parser)]
@@ -137,27 +129,6 @@ enum Commands {
         #[clap(long, short, action, help = "Return the results in JSON format")]
         json: bool,
     },
-    #[cfg(any(target_os = "macos", target_os = "linux"))]
-    /// Automatically turn the Logitech Litra device on when your webcam turns on, and off when the webcam turns off
-    AutoToggle {
-        #[clap(long, short, help = "The serial number of the Logitech Litra device")]
-        serial_number: Option<String>,
-        #[clap(long, short, action, help = "Output detailed log messages")]
-        verbose: bool,
-    },
-}
-
-#[cfg(target_os = "linux")]
-fn get_video_device_paths() -> std::io::Result<Vec<std::path::PathBuf>> {
-    Ok(std::fs::read_dir("/dev")?
-        .filter_map(|entry| entry.ok())
-        .filter_map(|e| {
-            e.file_name()
-                .to_str()
-                .filter(|name| name.starts_with("video"))
-                .map(|_| e.path())
-        })
-        .collect())
 }
 
 fn percentage_within_range(percentage: u32, start_range: u32, end_range: u32) -> u32 {
@@ -196,8 +167,6 @@ fn check_serial_number_if_some(serial_number: Option<&str>) -> impl Fn(&Device) 
 #[derive(Debug)]
 enum CliError {
     DeviceError(DeviceError),
-    #[cfg(any(target_os = "macos", target_os = "linux"))]
-    IoError(std::io::Error),
     SerializationFailed(serde_json::Error),
     BrightnessPercentageCalculationFailed(TryFromIntError),
     InvalidBrightness(i16),
@@ -208,8 +177,6 @@ impl fmt::Display for CliError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             CliError::DeviceError(error) => error.fmt(f),
-            #[cfg(any(target_os = "macos", target_os = "linux"))]
-            CliError::IoError(error) => write!(f, "Input/output error: {}", error),
             CliError::SerializationFailed(error) => error.fmt(f),
             CliError::BrightnessPercentageCalculationFailed(error) => {
                 write!(f, "Failed to calculate brightness: {}", error)
@@ -225,13 +192,6 @@ impl fmt::Display for CliError {
 impl From<DeviceError> for CliError {
     fn from(error: DeviceError) -> Self {
         CliError::DeviceError(error)
-    }
-}
-
-#[cfg(any(target_os = "macos", target_os = "linux"))]
-impl From<std::io::Error> for CliError {
-    fn from(error: std::io::Error) -> Self {
-        CliError::IoError(error)
     }
 }
 
@@ -476,113 +436,7 @@ fn handle_temperature_down_command(serial_number: Option<&str>, value: u16) -> C
     Ok(())
 }
 
-#[cfg(target_os = "macos")]
-async fn handle_autotoggle_command(serial_number: Option<&str>, verbose: bool) -> CliResult {
-    let context = Litra::new()?;
-    let device_handle = get_first_supported_device(&context, serial_number)?;
-
-    println!("Starting `log` process to listen for video device events...");
-
-    let mut child = Command::new("log")
-        .arg("stream")
-        .arg("--predicate")
-        .arg("subsystem == \"com.apple.cmio\" AND (eventMessage CONTAINS \"AVCaptureSession_Tundra startRunning\" || eventMessage CONTAINS \"AVCaptureSession_Tundra stopRunning\")")
-        .stdout(Stdio::piped())
-        .spawn()?;
-
-    let stdout = child
-        .stdout
-        .take()
-        .expect("Failed to start `log` process to listen for video device events");
-    let mut reader = BufReader::new(stdout).lines();
-
-    println!("Listening for video device events...");
-
-    while let Some(log_line) = reader
-        .next_line()
-        .await
-        .expect("Failed to read log line from `log` process when listening for video device events")
-    {
-        if !log_line.starts_with("Filtering the log data") {
-            if verbose {
-                println!("{}", log_line);
-            }
-
-            if log_line.contains("AVCaptureSession_Tundra startRunning") {
-                println!("Video device turned on, turning on Litra device");
-                device_handle.set_on(true)?;
-            } else if log_line.contains("AVCaptureSession_Tundra stopRunning") {
-                println!("Video device turned off, turning off Litra device");
-                device_handle.set_on(false)?;
-            }
-        }
-    }
-
-    let status = child.wait().await.expect(
-        "Something went wrong with the `log` process when listening for video device events",
-    );
-
-    Err(CliError::IoError(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        format!(
-            "`log` process exited unexpectedly when listening for video device events - {}",
-            status
-        ),
-    )))
-}
-
-#[cfg(target_os = "linux")]
-async fn handle_autotoggle_command(serial_number: Option<&str>, _verbose: bool) -> CliResult {
-    let context = Litra::new()?;
-    let device_handle = get_first_supported_device(&context, serial_number)?;
-
-    let mut inotify = Inotify::init()?;
-    for path in get_video_device_paths()? {
-        match inotify
-            .watches()
-            .add(&path, WatchMask::OPEN | WatchMask::CLOSE)
-        {
-            Ok(_) => println!("Watching device {}", path.display()),
-            Err(_) => eprintln!("Failed to watch device {}", path.display()),
-        }
-    }
-
-    let mut num_devices_open: usize = 0;
-    loop {
-        // Read events that were added with `Watches::add` above.
-        let mut buffer = [0; 1024];
-        let events = inotify.read_events_blocking(&mut buffer)?;
-        for event in events {
-            match event.mask {
-                EventMask::OPEN => {
-                    match event.name.and_then(std::ffi::OsStr::to_str) {
-                        Some(name) => println!("Video device opened: {}", name),
-                        None => println!("Video device opened"),
-                    }
-                    num_devices_open = num_devices_open.saturating_add(1);
-                }
-                EventMask::CLOSE_WRITE | EventMask::CLOSE_NOWRITE => {
-                    match event.name.and_then(std::ffi::OsStr::to_str) {
-                        Some(name) => println!("Video device closed: {}", name),
-                        None => println!("Video device closed"),
-                    }
-                    num_devices_open = num_devices_open.saturating_sub(1);
-                }
-                _ => (),
-            }
-        }
-        if num_devices_open == 0 {
-            println!("No video devices open, turning off light");
-            device_handle.set_on(false)?;
-        } else {
-            println!("{} video devices open, turning on light", num_devices_open);
-            device_handle.set_on(true)?;
-        }
-    }
-}
-
-#[tokio::main]
-async fn main() -> ExitCode {
+fn main() -> ExitCode {
     let args = Cli::parse();
 
     let result = match &args.command {
@@ -609,11 +463,6 @@ async fn main() -> ExitCode {
             serial_number,
             value,
         } => handle_temperature_command(serial_number.as_deref(), *value),
-        #[cfg(any(target_os = "macos", target_os = "linux"))]
-        Commands::AutoToggle {
-            serial_number,
-            verbose,
-        } => handle_autotoggle_command(serial_number.as_deref(), *verbose).await,
         Commands::TemperatureUp {
             serial_number,
             value,


### PR DESCRIPTION
This drops the `litra auto-toggle` command, which I have moved to a separate [`timrogers/litra-autotoggle`](https://github.com/timrogers/litra-autotoggle) package.

This allows us to keep the complex dependencies for auto-toggling clean and separate, and gives us a really smooth experience for running in the background.