### PR TITLE
v2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "litra"
-version = "1.6.0"
+version = "2.0.0"
 dependencies = [
  "clap",
  "hidapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "litra"
-version = "1.6.0"
+version = "2.0.0"
 edition = "2021"
 authors = ["Tim Rogers <timrogers@github.com>"]
 description = "Control your Logitech Litra light from the command line"


### PR DESCRIPTION
* **BREAKING CHANGE**: Remove the `auto-toggle` command for automatically turning your Litra on and off when your webcam turns on and off. This has now been moved to a separate tool, [`timrogers/litra-autotoggle`](https://github.com/timrogers/litra-autotoggle), which is easier to run in the background.