### PR TITLE
Update installation instructions to include Homebrew use on Linux, and don't automatically update the Homebrew formula on release

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -214,24 +214,6 @@ jobs:
             litra_${{ steps.sanitise_ref.outputs.value }}_darwin-arm64
             litra_${{ steps.sanitise_ref.outputs.value }}_linux-amd64
             litra_${{ steps.sanitise_ref.outputs.value }}_darwin-universal
-  publish_on_homebrew:
-    name: Publish release on Homebrew
-    runs-on: ubuntu-latest
-    needs: create_github_release
-    if: startsWith(github.event.ref, 'refs/tags/v')
-    steps:
-      - name: Get released version
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
-      - uses: mislav/bump-homebrew-formula-action@v3
-        with:
-          formula-name: litra
-          download-url: https://github.com/timrogers/litra-rs/releases/download/${{ steps.get_version.outputs.VERSION }}/litra_${{ steps.get_version.outputs.VERSION }}_darwin-universal
-          homebrew-tap: timrogers/homebrew-tap
-          push-to: timrogers/homebrew-tap
-          create-pullrequest: true
-        env:
-          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
   cargo_publish:
     name: Publish with Cargo to Crates.io
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -26,18 +26,18 @@ The following Logitech Litra devices, __connected via USB__, are supported:
 
 ## Installation
 
-### macOS with [Homebrew](https://brew.sh/)
+### macOS or Linux via [Homebrew](https://brew.sh/)
 
 1. Install the latest version by running `brew tap timrogers/tap && brew install litra`.
 1. Run `litra --help` to check that everything is working and see the available commands.
 
-### All other platforms (using Cargo)
+### macOS, Linux or Windows via [Cargo](https://doc.rust-lang.org/cargo/), Rust's package manager
 
 1. Install [Rust](https://www.rust-lang.org/tools/install) on your machine, if it isn't already installed.
 1. Install the `litra` crate by running `cargo install litra`.
 1. Run `litra --help` to check that everything is working and see the available commands.
 
-### All other platforms (via binary)
+### macOS, Linux or Windows via direct binary download
 
 1. Download the [latest release](https://github.com/timrogers/litra-rs/releases/latest) for your platform. macOS, Linux and Windows devices are supported.
 2. Add the binary to `$PATH`, so you can execute it from your shell. For the best experience, call it `litra` on macOS and Linux, and `litra.exe` on Windows.


### PR DESCRIPTION
Our Homebrew formula now supports installation on Linux as well as macOS.

This updates the README to make it clear that you can install that way (which is the easiest way!), and makes a few other tweaks along the way.

I also stop automatically updating the Homebrew formula on release - this automation was great, but it doesn't work once you have a more complex formula supporting multiple platforms.