### PR TITLE
Use Rust 1.83 in CI and simplify CI setup

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -217,7 +217,5 @@ jobs:
       - name: Use Rust 1.83.0 with target ${{ matrix.job.target }}
         run: rustup override set 1.83.0-${{ matrix.job.target }}
       - uses: Swatinem/rust-cache@v2
-      - name: Build in release mode
-        run: cargo build --release --target=${{ matrix.job.target }}
       - name: Publish to Crates.io
         run: cargo publish --token ${{ secrets.CRATES_IO_API_TOKEN }}

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -12,54 +12,45 @@ jobs:
           - {
               target: x86_64-unknown-linux-gnu,
               binary_name: linux-amd64,
-              os: ubuntu-latest,
+              runs_on: ubuntu-latest,
             }
           - {
               target: aarch64-unknown-linux-gnu,
               binary_name: linux-aarch64,
-              os: self-hosted,
+              runs_on: self-hosted,
             }
           - {
               target: x86_64-apple-darwin,
               binary_name: darwin-amd64,
-              os: macos-latest,
+              runs_on: macos-latest,
             }
           - {
               target: aarch64-apple-darwin,
               binary_name: darwin-aarch64,
-              os: macos-latest,
+              runs_on: macos-latest,
             }
           - {
               target: x86_64-pc-windows-msvc,
               binary_name: windows-amd64.exe,
-              os: windows-latest,
+              runs_on: windows-latest,
             }
-    runs-on: ${{ matrix.job.os }}
+    runs-on: ${{ matrix.job.runs_on }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Install rustup (self-hosted runners only)
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        if: matrix.job.runs_on == 'self-hosted'
+      - name: Add $HOME/.cargo/bin to PATH (self-hosted runners only)
+        run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        if: matrix.job.runs_on == 'self-hosted'
       - name: Install libudev-dev
         run: sudo apt-get update && sudo apt-get install libudev-dev
-        if: matrix.job.os == 'ubuntu-latest' || matrix.job.os == 'self-hosted'
-      - name: Cache Rust dependencies
-        uses: actions/cache@v4.1.2
-        with:
-          path: target
-          key: ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.OS }}-build-
-      - name: Install latest Rust nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          components: rustc, cargo
-          toolchain: nightly
-          override: true
-          target: ${{ matrix.job.target }}
-      - name: Run cargo build --release
-        uses: actions-rs/cargo@v1
-        with:
-          args: --release --target=${{ matrix.job.target }}
-          command: build
+        if: runner.os == 'Linux'
+      - uses: actions/checkout@v4
+      - name: Use Rust 1.83.0 with target ${{ matrix.job.target }}
+        run: rustup override set 1.83.0-${{ matrix.job.target }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Build in release mode
+        run: cargo build --release --target=${{ matrix.job.target }}
       - name: Sanitise Git ref for use in filenames
         id: sanitise_ref
         run: echo "::set-output name=value::$(echo "${{ github.ref_name }}" | tr '/' '_')"
@@ -76,12 +67,12 @@ jobs:
         env:
           APPLE_SIGNING_KEY_P12: ${{ secrets.APPLE_SIGNING_KEY_P12 }}
         run: echo "$APPLE_SIGNING_KEY_P12" | base64 -d -o key.p12
-        if: matrix.job.os == 'macos-latest'
+        if: runner.os == 'macOS'
       - name: Write App Store Connect API key to a file (macOS only)
         env:
           APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
         run: echo "$APP_STORE_CONNECT_API_KEY" > app_store_connect_api_key.json
-        if: matrix.job.os == 'macos-latest'
+        if: runner.os == 'macOS'
       - name: Sign macOS binary (macOS only)
         uses: indygreg/apple-code-sign-action@v1
         with:
@@ -90,7 +81,7 @@ jobs:
           p12_password: ${{ secrets.APPLE_SIGNING_KEY_PASSWORD }}
           sign: true
           sign_args: "--code-signature-flags=runtime"
-        if: matrix.job.os == 'macos-latest'
+        if: runner.os == 'macOS'
       - name: Upload binary as artifact
         uses: actions/upload-artifact@v4
         with:
@@ -98,7 +89,7 @@ jobs:
           name: litra_${{ steps.sanitise_ref.outputs.value }}_${{ matrix.job.binary_name }}
       - name: Archive macOS binary for notarisation (macOS only)
         run: zip litra_${{ steps.sanitise_ref.outputs.value }}_${{ matrix.job.binary_name }}.zip litra_${{ steps.sanitise_ref.outputs.value }}_${{ matrix.job.binary_name }}
-        if: matrix.job.os == 'macos-latest'
+        if: runner.os == 'macOS'
       - name: Notarise signed macOS binary (macOS only)
         uses: indygreg/apple-code-sign-action@v1
         with:
@@ -106,7 +97,7 @@ jobs:
           sign: false
           notarize: true
           app_store_connect_api_key_json_file: app_store_connect_api_key.json
-        if: matrix.job.os == 'macos-latest'
+        if: runner.os == 'macOS'
   create_and_sign_macos_universal_binary:
     name: Create and sign macOS universal binary (macOS only)
     runs-on: macos-latest
@@ -164,20 +155,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install libudev-dev
         run: sudo apt-get update && sudo apt-get install libudev-dev
-      - name: Cache Rust dependencies
-        uses: actions/cache@v4.1.2
-        with:
-          path: target
-          key: ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.OS }}-build-
-      - name: Install latest Rust nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          components: rustc, cargo
-          toolchain: nightly
-          override: true
+      - name: Use Rust 1.83.0
+        run: rustup override set 1.83.0
+      - uses: Swatinem/rust-cache@v2
       - name: Install cargo-edit
         run: cargo install cargo-edit
       - name: Set the version to a dummy version to allow publishing
@@ -234,19 +214,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install libudev-dev
         run: sudo apt-get update && sudo apt-get install libudev-dev
-      - name: Cache Rust dependencies
-        uses: actions/cache@v4.1.2
-        with:
-          path: target
-          key: ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.OS }}-build-
-      - name: Install latest Rust nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          components: rustc, cargo
-          toolchain: nightly
-          override: true
+      - name: Use Rust 1.83.0 with target ${{ matrix.job.target }}
+        run: rustup override set 1.83.0-${{ matrix.job.target }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Build in release mode
+        run: cargo build --release --target=${{ matrix.job.target }}
       - name: Publish to Crates.io
         run: cargo publish --token ${{ secrets.CRATES_IO_API_TOKEN }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,40 +8,40 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - name: Install libudev-dev
-      run: sudo apt-get update && sudo apt-get install libudev-dev
+      - name: Install libudev-dev
+        run: sudo apt-get update && sudo apt-get install libudev-dev
 
-    - name: Install latest Rust nightly
-      uses: actions-rs/toolchain@v1
-      with:
-          toolchain: nightly
-          override: true
-          components: rustc, rustfmt, clippy
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
-    - name: Check out repository
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 2
+      - name: Set up Python
+        uses: actions/setup-python@v5
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
+      - name: Use Rust 1.83.0
+        run: rustup override set 1.83.0
 
-    - name: Detect code style issues
-      uses: pre-commit/action@v3.0.1
-      env:
-        SKIP: no-commit-to-branch
+      - run: rustup component add clippy rustfmt
 
-    - name: Generate patch file
-      if: failure()
-      run: |
-        git diff-index -p HEAD > "${PATCH_FILE}"
-        [ -s "${PATCH_FILE}" ] && echo "UPLOAD_PATCH_FILE=${PATCH_FILE}" >> "${GITHUB_ENV}"
-      env:
-        PATCH_FILE: pre-commit.patch
+      - uses: Swatinem/rust-cache@v2
 
-    - name: Upload patch artifact
-      if: failure() && env.UPLOAD_PATCH_FILE != null
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ env.UPLOAD_PATCH_FILE }}
-        path: ${{ env.UPLOAD_PATCH_FILE }}
+      - name: Detect code style issues
+        uses: pre-commit/action@v3.0.1
+        env:
+          SKIP: no-commit-to-branch
+
+      - name: Generate patch file
+        if: failure()
+        run: |
+          git diff-index -p HEAD > "${PATCH_FILE}"
+          [ -s "${PATCH_FILE}" ] && echo "UPLOAD_PATCH_FILE=${PATCH_FILE}" >> "${GITHUB_ENV}"
+        env:
+          PATCH_FILE: pre-commit.patch
+
+      - name: Upload patch artifact
+        if: failure() && env.UPLOAD_PATCH_FILE != null
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.UPLOAD_PATCH_FILE }}
+          path: ${{ env.UPLOAD_PATCH_FILE }}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.83.0"
+components = [ "rustc", "rustfmt", "clippy" ]
+targets = [ "x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin", "x86_64-pc-windows-msvc" ]
+profile = "minimal"


### PR DESCRIPTION
This tweaks our CI setup in GitHub Actions to always use Rust 1.83, the current stable version, rather than a nightly release. This should help to avoid [surprising red builds][1] due to changes in Rust.

As part of this change, I've also dropped the use of deprecated `actions-rs` actions and done some other refactoring of the CI pipelines.

[1]: https://github.com/timrogers/litra-rs/actions/runs/12096478002