### PR TITLE
Allow other packages to be installed and upgraded when installing `libudev-dev` in CI

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Add $HOME/.cargo/bin to PATH (self-hosted runners only)
         run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
         if: matrix.job.runs_on == 'self-hosted'
-      - name: Install libudev-dev
-        run: sudo apt-get update && sudo apt-get install libudev-dev
+      - name: install -y libudev-dev
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev
         if: runner.os == 'Linux'
       - uses: actions/checkout@v4
       - name: Use Rust 1.83.0 with target ${{ matrix.job.target }}
@@ -153,8 +153,8 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v4
-      - name: Install libudev-dev
-        run: sudo apt-get update && sudo apt-get install libudev-dev
+      - name: install -y libudev-dev
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev
       - name: Use Rust 1.83.0
         run: rustup override set 1.83.0
       - uses: Swatinem/rust-cache@v2
@@ -212,8 +212,8 @@ jobs:
     if: startsWith(github.event.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v4
-      - name: Install libudev-dev
-        run: sudo apt-get update && sudo apt-get install libudev-dev
+      - name: install -y libudev-dev
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev
       - name: Use Rust 1.83.0 with target ${{ matrix.job.target }}
         run: rustup override set 1.83.0-${{ matrix.job.target }}
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Add $HOME/.cargo/bin to PATH (self-hosted runners only)
         run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
         if: matrix.job.runs_on == 'self-hosted'
-      - name: install -y libudev-dev
+      - name: Install libudev-dev
         run: sudo apt-get update && sudo apt-get install -y libudev-dev
         if: runner.os == 'Linux'
       - uses: actions/checkout@v4
@@ -153,7 +153,7 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v4
-      - name: install -y libudev-dev
+      - name: Install libudev-dev
         run: sudo apt-get update && sudo apt-get install -y libudev-dev
       - name: Use Rust 1.83.0
         run: rustup override set 1.83.0
@@ -212,7 +212,7 @@ jobs:
     if: startsWith(github.event.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v4
-      - name: install -y libudev-dev
+      - name: Install libudev-dev
         run: sudo apt-get update && sudo apt-get install -y libudev-dev
       - name: Use Rust 1.83.0 with target ${{ matrix.job.target }}
         run: rustup override set 1.83.0-${{ matrix.job.target }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,8 +8,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - name: Install libudev-dev
-        run: sudo apt-get update && sudo apt-get install libudev-dev
+      - name: install -y libudev-dev
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev
 
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,7 +8,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - name: install -y libudev-dev
+      - name: Install libudev-dev
         run: sudo apt-get update && sudo apt-get install -y libudev-dev
 
       - name: Check out repository


### PR DESCRIPTION
This should fix the new CI failure seen [here][1].

[1]: https://github.com/timrogers/litra-rs/actions/runs/13097492161/job/36541564869