### PR TITLE
Allow controlling the coloured side of the Litra Beam LX

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ impl fmt::Display for DeviceError {
             DeviceError::UnsupportedDeviceType => write!(f, "Unsupported device type"),
             DeviceError::InvalidZone(zone_id) => write!(
                 f,
-                "Back color zone {} is not valid. Only zones 1-8 are allowed.",
+                "Back color zone {} is not valid. Only zones 1-7 are allowed.",
                 zone_id
             ),
             DeviceError::InvalidColor(str) => write!(
@@ -405,8 +405,8 @@ impl DeviceHandle {
             return Err(DeviceError::UnsupportedDeviceType);
         }
 
-        // The device is divided in 8 sections
-        if zone_id == 0 || zone_id > 8 {
+        // The device is divided into 7 sections
+        if zone_id == 0 || zone_id > 7 {
             return Err(DeviceError::InvalidZone(zone_id));
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,9 +137,10 @@ enum Commands {
         value: Option<u16>,
         #[clap(
             long,
-            short,
+            short('b'),
             help = "The brightness to set, as a percentage of the maximum brightness",
-            group = "brightness"
+            group = "brightness",
+            value_parser = clap::value_parser!(u8).range(1..=100)
         )]
         percentage: Option<u8>,
     },
@@ -171,7 +172,8 @@ enum Commands {
             long,
             short,
             help = "The number of percentage points to increase the brightness by",
-            group = "brightness-up"
+            group = "brightness-up",
+            value_parser = clap::value_parser!(u8).range(1..=100)
         )]
         percentage: Option<u8>,
     },
@@ -203,7 +205,8 @@ enum Commands {
             long,
             short,
             help = "The number of percentage points to reduce the brightness by",
-            group = "brightness-down"
+            group = "brightness-down",
+            value_parser = clap::value_parser!(u8).range(1..=100)
         )]
         percentage: Option<u8>,
     },
@@ -299,7 +302,7 @@ enum Commands {
         #[clap(
             long,
             short,
-            help = "The zone of the light to control, numbered 1 to 8 from left to right. If not specified, all zones will be targeted."
+            help = "The zone of the light to control, numbered 1 to 7 from left to right. If not specified, all zones will be targeted."
         )]
         zone: Option<u8>,
     },
@@ -320,7 +323,8 @@ enum Commands {
         #[clap(
             long,
             short('b'),
-            help = "The brightness to set, as a percentage of the maximum brightness"
+            help = "The brightness to set, as a percentage of the maximum brightness",
+            value_parser = clap::value_parser!(u8).range(1..=100)
         )]
         percentage: u8,
     },
@@ -965,8 +969,9 @@ fn handle_back_color_command(
         |device_handle| match hex_to_rgb(hex) {
             Ok((r, g, b)) => match zone_id {
                 None => {
-                    for i in 1..=8 {
+                    for i in 1..=7 {
                         device_handle.set_back_color(i, r, g, b)?;
+                        std::thread::sleep(std::time::Duration::from_millis(10));
                     }
                     Ok(())
                 }


### PR DESCRIPTION
This builds on @aleixpol's work in https://github.com/timrogers/litra-rs/pull/185, adding support for controlling the coloured side of the Litra Beam LX.

This PR also contains additional changes:

* Fix display of validation errors when using the CLI
* Use `-b` as the short form for the `--percentage` argument for `brightness`, `brightness-up` and `brightness-down` to avoid clashing with `--device-path`
* Validate percentage passed to `brightness`, `brightness-up` and `brightness-down` and error for invalid percentages

Fixes https://github.com/timrogers/litra-rs/issues/123.