### PR TITLE
v3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "litra"
-version = "2.5.2"
+version = "3.0.0"
 dependencies = [
  "clap",
  "hidapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "litra"
-version = "2.5.2"
+version = "3.0.0"
 edition = "2021"
 authors = ["Tim Rogers <timrogers@github.com>"]
 description = "Control Logitech Litra lights from the command line, Model Context Protocol (MCP) clients and Rust applications"


### PR DESCRIPTION
* Add support for managing the colorful back side of Litra Beam LX devices with new CLI commands (e.g. `back-toggle`, `back-color`, `back-brightness`), MCP tools and Rust methods
* Expose the on/off state and brightness of the back side of the Litra Beam LX in the `litra devices` CLI command, MCP tools and Rust API
* **BREAKING CHANGE**: Change the structure of output from the `litra devices --json` CLI command
  * Rename the `status` field to `status_display`, matching other human-readable fields
  * Rename the `device_type` field to `device_type_display`, matching other human-readable fields
* Return a machine-readable device type (e.g. `beam`) in the output of `litra devices --json`, matching the values accepted by other CLI commands
* Fix display of validation errors when using the CLI
* Use `-b` as the short form of the `--percentage` argument for `brightness`, `brightness-up` and `brightness-down` to avoid clashing with `--device-path`
* Validate percentage passed to `brightness`, `brightness-up` and `brightness-down` and error for invalid percentages

Thanks to:

* @aleixpol for the amazing work on the new Litra Beam LX support 💜
* @liyuwen356-collab for financial support via [GitHub Sponsors][1] to buy a Litra Beam LX to get this over the line ✨

[1]: https://github.com/sponsors/timrogers