### PR TITLE
Return devices from litra devices CLI command and underlying Rust API in a stable order

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ impl Litra {
             .device_list()
             .filter_map(|device_info| Device::try_from(device_info).ok())
             .collect();
-        devices.sort_by(|a, b| a.device_path().cmp(&b.device_path()));
+        devices.sort_by_key(|a| a.device_path());
         devices.into_iter()
     }
 


### PR DESCRIPTION
Previously, the order of devices returned was non-deterministic, which could be a bit of a pain when rendering UI. Now, the devices are returned in a deterministic order, sorted by their device path.