### PR TITLE
ci: bound triggers, bump Rust to 1.95.0, run tests in matrix

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -1,6 +1,13 @@
 name: Build, test and release
 
-on: push
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+    tags: "*"
 
 jobs:
   build:
@@ -51,8 +58,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libudev-dev
         if: runner.os == 'Linux'
       - uses: actions/checkout@v6
-      - name: Use Rust 1.92.0 with target ${{ matrix.job.target }}
-        run: rustup override set 1.92.0-${{ matrix.job.target }}
+      - name: Use Rust 1.95.0 with target ${{ matrix.job.target }}
+        run: rustup override set 1.95.0-${{ matrix.job.target }}
       - uses: Swatinem/rust-cache@v2
       - name: Build in release mode
         run: cargo build --release --target=${{ matrix.job.target }}
@@ -160,8 +167,8 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install libudev-dev
         run: sudo apt-get update && sudo apt-get install -y libudev-dev
-      - name: Use Rust 1.92.0
-        run: rustup override set 1.92.0
+      - name: Use Rust 1.95.0
+        run: rustup override set 1.95.0
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-edit
         run: cargo install cargo-edit
@@ -223,8 +230,8 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install libudev-dev
         run: sudo apt-get update && sudo apt-get install -y libudev-dev
-      - name: Use Rust 1.92.0
-        run: rustup override set 1.92.0
+      - name: Use Rust 1.95.0
+        run: rustup override set 1.95.0
       - uses: Swatinem/rust-cache@v2
       - name: Publish to Crates.io
         run: cargo publish --token ${{ secrets.CRATES_IO_API_TOKEN }}

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -61,6 +61,8 @@ jobs:
       - name: Use Rust 1.95.0 with target ${{ matrix.job.target }}
         run: rustup override set 1.95.0-${{ matrix.job.target }}
       - uses: Swatinem/rust-cache@v2
+      - name: Run tests
+        run: cargo test --target=${{ matrix.job.target }}
       - name: Build in release mode
         run: cargo build --release --target=${{ matrix.job.target }}
       - name: Sanitise Git ref for use in filenames

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.92.0"
+channel = "1.95.0"
 components = [ "rustc", "rustfmt", "clippy" ]
 targets = [ "x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin", "x86_64-pc-windows-msvc" ]
 profile = "minimal"


### PR DESCRIPTION
## Summary

Replicates a few CI patterns already in use in `litra-autotoggle`:

- **Scope `build_and_release.yml` triggers** to PRs into `main`, pushes to `main`, and tag pushes. The previous `on: push` ran the full six-platform matrix (with macOS notarisation) on every feature-branch push.
- **Bump the pinned Rust toolchain** from `1.92.0` to `1.95.0` in `rust-toolchain.toml` and the three `rustup override set` references inside the workflow.
- **Run `cargo test --target=...`** in every matrix entry, before the release build, so cross-platform regressions surface in CI rather than at release time.

## Test plan

- [ ] CI run on this PR completes successfully on all six matrix targets
- [ ] `cargo test` step passes on Linux (amd64 + aarch64), macOS (amd64 + aarch64), and Windows (amd64 + arm64)
- [ ] Release build still produces the expected `litra_*` artefacts
- [ ] Confirm the workflow no longer runs on pushes to non-`main` branches (e.g. by pushing a throwaway branch after merge)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DeaKVn5Mjct62H3DX8henh)_